### PR TITLE
Add a room config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+## [1.0.1] - 2018-04-17
+### Added
+- `room` parameter to general config. [Documentation](/docs/install.md#room).
+
+### Changed
+- Card properties are now prefixed with `card_` for the Home Assistant Action.
+
+## [1.0.0] - 2018-04-09
+### Added
+- Initial Release

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -1,4 +1,5 @@
 {
+  "room": "Living Room",
   "input_device": "event0",
   "spotify": {
     "clientID": "XXX",

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -148,7 +148,7 @@ If you have [Home Assistant](https://home-assistant.io) set up at home, integrat
 
 The Home Assistant action simply pushes the event `magic_card_scanned`. All you have to do is set up an automation that uses that event as a trigger.
 
-Magic Cards delivers all of the card's properties when it pushes the events, so they're available to you in your automation. Use `trigger.event.data` in your automation templates to get the data. Ex: `trigger.event.data.uri`, `trigger.event.data.title`.
+Magic Cards delivers all of the card's properties in the event data payload prefixed with `card_` when it pushes the events, so they're available to you in your automation. Use `trigger.event.data` in your automation templates to get the data. Ex: `trigger.event.data.card_uri`, `trigger.event.data.card_title`.
 
 ### Card URI
 
@@ -169,15 +169,15 @@ automation:
       - platform: event
         event_type: magic_card_scanned
         event_data:
-          type: album
+          card_type: album
     action:
       - service: media_player.select_source
         data_template:
-          entity_id: "media_player.{{ trigger.event.data.uri.split('|')[0] }}"
-          source: "{{ trigger.event.data.uri.split('|')[1] }}"
+          entity_id: "media_player.{{ trigger.event.data.card_uri.split('|')[0] }}"
+          source: "{{ trigger.event.data.card_uri.split('|')[1] }}"
 ```
 
-When triggered, the automation reads from the URI property and uses the first part to set the entity id of the media player that will be used. It uses the second part as the name of the source that should be played.
+When triggered, this automation reads from the card's URI property and uses the first part to set the entity id of the media player that will be used. It uses the second part as the name of the source that should be played.
 
 ### Home Assistant Action Configuration
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -162,6 +162,7 @@ This is the main configuration file. You'll need to edit a few things. Here's an
 
 ```json
 {
+  "room": "Living Room",
   "input_device": "event0",
   "spotify": {
     "clientID": "XXX",
@@ -171,6 +172,10 @@ This is the main configuration file. You'll need to edit a few things. Here's an
 ```
 
 You need to define which input device that Magic Cards uses to detect card scanning. If the only thing you have plugged into the Pi is the scanner, more than likely it'll be `event0`. Otherwise you'll have to determine which device it is by looking in the `/dev/input` directory on your Pi.
+
+#### Room
+
+The `room` setting lets you assign your Magic Cards setup to a room. This value will be passed along to actions as the `magic_cards_room` attribute. This lets your automations know which room the card was scanned from.
 
 #### Spotify
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-cards",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Jon Maddox <jon@jonmaddox.com>",
   "license": "MIT",
   "bugs": {

--- a/scanner/actions/Action.js
+++ b/scanner/actions/Action.js
@@ -1,3 +1,5 @@
+const globalConfig = require(__dirname + '/../../config/config.json')
+
 class Action {
   constructor(card, config) {
     delete config.action
@@ -27,7 +29,8 @@ class Action {
   }
 
   envVars() {
-    const envVars = this.envVarsForObject(this.card, 'CARD')
+    let envVars = this.envVarsForObject(this.card, 'CARD')
+    envVars = Object.assign(envVars, {magic_cards_room: globalConfig.room})
 
     const prefix = this.constructor.name.replace('Action', '').toUpperCase()
     return Object.assign(envVars, this.envVarsForObject(this.config, prefix))

--- a/scanner/actions/HomeAssistantAction.js
+++ b/scanner/actions/HomeAssistantAction.js
@@ -18,7 +18,7 @@ class HomeAssistantAction extends Action {
       payload[key.toLowerCase()] = envVars[key]
     })
 
-    return this.card
+    return payload
   }
 
   async request(payload) {


### PR DESCRIPTION
This adds the ability to set the name of the room your Magic Cards setup is in.

This value will be passed along to actions as the `magic_cards_room` attribute. This lets your automations know which room the card was scanned from.
