### PR TITLE
Fix Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberry-pi-alpine-node
+FROM resin/raspberry-pi-alpine-node:9.11-slim
 
 RUN npm install yarn -g
 RUN npm install concurrently -g

--- a/client/package.json
+++ b/client/package.json
@@ -1,4 +1,7 @@
 {
+  "engines" : {
+    "node" : "9.11.1"
+  },
   "name": "magic-cards-client",
   "author": "Jon Maddox <jon@jonmaddox.com>",
   "license": "MIT",


### PR DESCRIPTION
This fixes the docker build since node 10.x came out. This pins Magic Cards to v9.11.x and ensures the docker container is pinned to that version too.