### PR TITLE
Queue not Now

### DIFF
--- a/client/src/utilities/Metadata.js
+++ b/client/src/utilities/Metadata.js
@@ -30,7 +30,7 @@ export default class Metadata {
       .then(data => {
         type = contentType
         title = data.name
-        uri = `spotify/now/${data.uri}`
+        uri = `spotify/queue/${data.uri}`
 
         if (data.artists && data.artists[0]) {
           subtitle = data.artists[0].name
@@ -83,7 +83,7 @@ export default class Metadata {
             subtitle = result.artistName
           }
 
-          uri = `applemusic/now/${type}:${itunesID}`
+          uri = `applemusic/queue/${type}:${itunesID}`
 
           return {type: type, artURL: artURL, title: title, subtitle: subtitle, uri: uri}
         })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-cards",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "Jon Maddox <jon@jonmaddox.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Previously, we were suggesting `/now/` for the card URI. This (when used with [node-sonos-http-api](https://github.com/jishi/node-sonos-http-api)) causes the queue to advance forward one track. This means we'd miss the first song every time.

Instead, since we're clearing the queue manually and playing manually, we just use `/queue/` to get the tracks into the queue.

If you were seeing this weird issue where it never played your first song on Sonos, change your card URIs to `/queue/`.