### PR TITLE
Bump node to 9.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/raspberry-pi-alpine-node:9.11.1
+FROM resin/raspberry-pi-alpine-node:9.11.2
 
 RUN npm install yarn -g
 RUN npm install concurrently -g

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "engines" : {
-    "node" : "9.11.1"
+    "node" : "9.11.2"
   },
   "name": "magic-cards-client",
   "author": "Jon Maddox <jon@jonmaddox.com>",

--- a/docs/install.md
+++ b/docs/install.md
@@ -106,7 +106,7 @@ You'll need to have node and yarn installed on your Pi before you start setting 
 If you don't have Node or yarn installed, here's some simple instructions. Using [this repo](https://github.com/sdesalas/node-pi-zero), you can get node installed with a single command:
 
 ```bash
-wget -O - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v9.8.0.sh | bash
+wget -O - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v9.11.2.sh | bash
 ```
 
 After you have node installed, edit your `~/.profile` file to add:


### PR DESCRIPTION
I just did an install following the [manual install instructions](https://github.com/maddox/magic-cards/blob/master/docs/install.md#nodejs--yarn) and I got this error:

```
error magic-cards-client@: The engine "node" is incompatible with this module. Expected version "9.11.1". Got "9.8.0"
error Found incompatible module
```

This was introduced in #14 when the client package.json got pinned to 9.11.1. The manual installation still has the user install Node 9.8.0. The repository linked in the manual installation contains installation scripts for 9.11.2 (the latest version), but not 9.11.1. 

This PR bumps the node versions to 9.11.2 for Docker, client/package.json and the manual installation instructions.