### PR TITLE
Clarify Home Assistant token

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -181,7 +181,7 @@ When triggered, this automation reads from the card's URI property and uses the 
 
 ### Home Assistant Action Configuration
 
-The Home Assistant configuration is pretty simple. Just point it at your Home Assistant install, provide a [long lived access token](https://developers.home-assistant.io/docs/en/auth_api.html#long-lived-access-token), and boom!
+The Home Assistant configuration is pretty simple. Just point it at your Home Assistant install, provide a long lived access token (in Home Assistant UI on the profile page), and boom!
 
 ```json
 {

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -181,7 +181,7 @@ When triggered, this automation reads from the card's URI property and uses the 
 
 ### Home Assistant Action Configuration
 
-The Home Assistant configuration is pretty simple. Just point it at your Home Assistant install, provide a long lived access token (in Home Assistant UI on the profile page), and boom!
+The Home Assistant configuration is pretty simple. Just point it at your Home Assistant install, provide a long lived access token, and boom! You can generate long lived access tokens via the Home Assistant UI on the profile page.
 
 ```json
 {


### PR DESCRIPTION
Clarify where to get long lived access tokens in Home Assistant. Instead of scaring people with the developer documentation and websocket commands, they should just use the UI.

![image](https://user-images.githubusercontent.com/1444314/52909179-d6835780-3238-11e9-9ea8-4e388799dbd9.png)
