### PR TITLE
Bail out of testing if no card code

### DIFF
--- a/client/src/components/EditableCard.js
+++ b/client/src/components/EditableCard.js
@@ -61,6 +61,11 @@ class EditableCard extends React.Component {
     event.preventDefault()
     event.stopPropagation()
 
+    if (!this.props.card.code) {
+      alert('Card has no card code. Test aborted.')
+      return
+    }
+
     const baseURL = process.env.NODE_ENV === 'development' ? 'http://localhost:5000' : ''
     const testerURL = baseURL + '/test/' + this.props.card.code
 


### PR DESCRIPTION
Testing a card requires a card code to be set. If no card code is set, it will fail but no feedback is given. This PR will show a warning to the user why the test won't work.

This is the second time that I set up Magic Cards without having the cards yet and it bit me again.