### PR TITLE
Add option to disable SSL verification when talking to Home Assistant

### DIFF
--- a/config/actions.example.json
+++ b/config/actions.example.json
@@ -24,6 +24,7 @@
     "host": "192.168.1.50",
     "port": "8123",
     "ssl": false,
+    "verify_ssl": true,
     "password": "hapassword"
   },
   "Family Room Channels": {

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -52,6 +52,7 @@ Magic Cards comes with an example actions configuration in `/config/actions.exam
     "host": "192.168.1.50",
     "port": "8123",
     "ssl": false,
+    "verify_ssl": true,
     "token": "hastoken"
   },
   "Family Room Channels": {
@@ -189,9 +190,12 @@ The Home Assistant configuration is pretty simple. Just point it at your Home As
   "host": "192.168.1.50",
   "port": "8123",
   "ssl": false,
+  "verify_ssl": true,
   "token": "hatoken"
 }
 ```
+
+If you are using SSL for Home Assistant but are connecting via an IP address, the certificate will be invalid. In that case, set `verify_ssl` to `false`.
 
 You can also authenticate using your [API password](https://www.home-assistant.io/docs/authentication/providers/#legacy-api-password) by replacing `"token"` with `"password"`. However, note that Home Assistant considers this a legacy feature that is likely to be dropped in a future release.
 

--- a/scanner/actions/HomeAssistantAction.js
+++ b/scanner/actions/HomeAssistantAction.js
@@ -1,6 +1,6 @@
 const fetch = require('node-fetch')
-const base64 = require('base-64')
 const Action = require('./Action')
+const https = require('https')
 
 class HomeAssistantAction extends Action {
   process() {
@@ -34,11 +34,20 @@ class HomeAssistantAction extends Action {
       headers['x-ha-access'] = this.config.password
     }
 
-    return fetch(baseURL, {
+    const init = {
       method: 'POST',
       headers: headers,
       body: JSON.stringify(payload),
-    })
+    }
+
+    // Compare to false so that we don't disable SSL if option omitted
+    if (this.config.verify_ssl === false) {
+      init.agent = new https.Agent({
+        rejectUnauthorized: false,
+      })
+    }
+
+    return fetch(baseURL, init)
       .then(res => res.text())
       .then(body => console.log(body))
       .catch(error => console.log(error))


### PR DESCRIPTION
If Home Assistant is exposed to the internet, it is most likely configured with an SSL cert. If your router does not support harpinning/NAT loopback, you will need to configure Magic Cards to talk directly to the local IP of the machine running Home Assistant. This will cause the SSL cert to be invalid (as it's bound to the DNS name).

This adds an option `verify_ssl` to the Home Assistant action, which will disable SSL verification when set to `false`.