### PR TITLE
Fix Apple Music Auto Fill

### DIFF
--- a/client/src/components/CardEditor.js
+++ b/client/src/components/CardEditor.js
@@ -165,7 +165,7 @@ class CardEditor extends React.Component {
             type="search"
             label="Add content by URL"
             name="query"
-            placeholder="https://itunes.apple.com/us/album/moana-original-motion-picture-soundtrack-deluxe-edition/1168827405"
+            placeholder="https://music.apple.com/us/album/moana-original-motion-picture-soundtrack-deluxe-edition/1168827405"
             onChange={this.handleUrl}
           />
         </Form>

--- a/client/src/utilities/Metadata.js
+++ b/client/src/utilities/Metadata.js
@@ -4,7 +4,7 @@ export default class Metadata {
   static async fetchMetadata(url) {
     const sourceURL = new URL(url)
 
-    if (sourceURL.host === 'itunes.apple.com') {
+    if (sourceURL.host === 'music.apple.com') {
       return Metadata.fromItunes(sourceURL)
     } else if (sourceURL.host === 'open.spotify.com') {
       return Metadata.fromSpotify(sourceURL)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magic-cards",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "author": "Jon Maddox <jon@jonmaddox.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
This fixes the autofill for Apple Music URLs. Previously, Apple Music provided URLs with the `itunes.apple.com` host. Now it uses `music.apple.com`.

This should work again.